### PR TITLE
Fix(dashboard): Prevent crash when user object is null

### DIFF
--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -190,7 +190,7 @@ const Dashboard = ({ children }) => {
 
   return (
     <>
-      {showOnboarding && (
+      {showOnboarding && user && (
         <OnboardingWizard
           onComplete={handleOnboardingComplete}
           onSkip={handleOnboardingSkip}


### PR DESCRIPTION
In the Dashboard component, a race condition could occur where the user object becomes null (e.g., on logout) while the component is still trying to render the OnboardingWizard, which depends on the user's ID.

This change adds a null check to ensure the user object exists before rendering the OnboardingWizard, preventing the "Cannot read properties of null (reading 'id')" TypeError and making the component more resilient.