### PR TITLE
feat(auth): add axios interceptor to handle 401 errors

### DIFF
--- a/frontend/src/utils/axiosConfig.js
+++ b/frontend/src/utils/axiosConfig.js
@@ -2,4 +2,25 @@ import axios from 'axios';
 
 axios.defaults.withCredentials = true;
 
+// Add a response interceptor
+axios.interceptors.response.use(
+  (response) => {
+    // Any status code that lie within the range of 2xx cause this function to trigger
+    return response;
+  },
+  (error) => {
+    // Any status codes that falls outside the range of 2xx cause this function to trigger
+    if (error.response && error.response.status === 401) {
+      // User is not authenticated, clear local storage and redirect to login
+      localStorage.removeItem('user');
+      localStorage.removeItem('token');
+      // Redirect to login page, preventing a redirect loop
+      if (window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default axios;


### PR DESCRIPTION
This commit introduces an Axios response interceptor to globally handle authentication failures.

When the backend session expires or becomes invalid, API calls from the frontend will receive a 401 Unauthorized status. This interceptor catches these responses, automatically clears the user's session data from local storage, and redirects the user to the login page.

This prevents the user from being in a "logged-in" state on the frontend while being unauthenticated on the backend, creating a more robust and predictable user experience.