### PR TITLE
fix: Correctly import plaidClient across the application

### DIFF
--- a/backend/src/db/queries/items.js
+++ b/backend/src/db/queries/items.js
@@ -1,6 +1,6 @@
 const PlaidItem = require('../../models/PlaidItem');
 const PlaidAccount = require('../../models/PlaidAccount');
-const plaidClient = require('../../config/plaidClient');
+const { client: plaidClient } = require('../../config/plaidClient');
 const { deleteTransactionsByAccountId } = require('./transactions');
 
 /**

--- a/backend/src/routes/plaid.js
+++ b/backend/src/routes/plaid.js
@@ -10,7 +10,7 @@
 
 const express = require('express');
 const router = express.Router();
-const plaidClient = require('../config/plaidClient');
+const { client: plaidClient } = require('../config/plaidClient');
 const PlaidDbService = require('../services/plaidDbService');
 const PlaidApiService = require('../services/plaidApiService');
 const PlaidItem = require('../models/PlaidItem');

--- a/backend/src/update_transactions.js
+++ b/backend/src/update_transactions.js
@@ -3,7 +3,7 @@
  */
 
 //const plaid = require('plaid');
-const plaidClient = require('./config/plaidClient');
+const { client: plaidClient } = require('./config/plaidClient');
 const {
   retrieveItemByPlaidItemId,
   createAccounts,


### PR DESCRIPTION
The plaidClient module exports an object containing the client instance. This commit updates the import statement in all affected files (`update_transactions.js`, `db/queries/items.js`, and `routes/plaid.js`) to correctly destructure the client. This resolves the 'plaidClient.accountsGet is not a function' and 'plaidClient.transactionsSync is not a function' errors and prevents future bugs related to this incorrect import.