### PR TITLE
feat: Implement Plaid update mode for re-authorization

### DIFF
--- a/backend/src/routes/plaid.js
+++ b/backend/src/routes/plaid.js
@@ -41,12 +41,22 @@ const PLAID_COUNTRY_CODES = (process.env.PLAID_COUNTRY_CODES || 'CA').split(',')
  */
 router.post('/create_link_token', async (req, res) => {
   try {
-    const { access_token, userId } = req.body;
+    const { itemId, userId } = req.body;
     const webhook = process.env.PLAID_WEBHOOK_URL;
+    let access_token = null;
 
     // Validate required fields
     if (!userId) {
       return res.status(400).json({ error: 'User ID is required' });
+    }
+
+    if (itemId) {
+      const item = await PlaidDbService.getItem(itemId);
+      if (item && item.userId.toString() === userId) {
+        access_token = item.accessToken;
+      } else {
+        return res.status(404).json({ error: 'Item not found or access denied' });
+      }
     }
 
     console.log('Sending Link Token Request:', userId, access_token, webhook);

--- a/backend/src/services/plaidApiService.js
+++ b/backend/src/services/plaidApiService.js
@@ -16,15 +16,20 @@ class PlaidApiService {
      */
     static async createLinkToken(userId, accessToken, webhook) {
         try {
-            const response = await plaidClient.linkTokenCreate({
+            const config = {
                 user: { client_user_id: userId },
                 client_name: 'ChaChing',
-                products: PLAID_PRODUCTS,
                 country_codes: PLAID_COUNTRY_CODES,
                 language: 'en',
-                access_token: accessToken,
                 webhook,
-            });
+                access_token: accessToken,
+            };
+
+            if (!accessToken) {
+                config.products = PLAID_PRODUCTS;
+            }
+
+            const response = await plaidClient.linkTokenCreate(config);
             console.log("LINK Country CODES:", PLAID_COUNTRY_CODES);
             return response.data;
         } catch (error) {

--- a/backend/src/services/plaidDbService.js
+++ b/backend/src/services/plaidDbService.js
@@ -84,6 +84,19 @@ class PlaidDbService {
     }
 
     /**
+     * Retrieves a single Plaid item by its ID
+     * @param {string} itemId - The ID of the item to retrieve
+     * @returns {Promise<Object>} The Plaid item document
+     */
+    static async getItem(itemId) {
+        try {
+            return await PlaidItem.findById(itemId);
+        } catch (error) {
+            throw new Error(`Failed to get item: ${error.message}`);
+        }
+    }
+
+    /**
      * Retrieves Plaid account IDs for a user
      * @param {string} userId - User ID
      * @returns {Promise<Array>} Array of account IDs

--- a/frontend/src/components/Accounts.js
+++ b/frontend/src/components/Accounts.js
@@ -25,6 +25,7 @@ import {
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import Breadcrumbs from "./Breadcrumbs";
 import PlaidLinkButton from './PlaidLinkButton';
+import PlaidLinkUpdate from './PlaidLinkUpdate';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -40,6 +41,7 @@ const Accounts = () => {
 
 
     const [unlinkSuccess, setUnlinkSuccess] = useState(false);
+    const [reauthSuccess, setReauthSuccess] = useState(false);
 
     const handlePlaidExit = (error, metadata) => {
         if (error) {
@@ -198,6 +200,23 @@ const Accounts = () => {
                                                     <IconButton onClick={() => toggleCollapse(itemId)}>
                                                         {collapsedInstitutions.includes(itemId) ? <ExpandMoreIcon /> : <ExpandLessIcon />}
                                                     </IconButton>
+                                                    <PlaidLinkUpdate
+                                                        itemId={itemId}
+                                                        onUpdateSuccess={() => {
+                                                            fetchAccounts();
+                                                            setReauthSuccess(true);
+                                                        }}
+                                                        onUpdateExit={handlePlaidExit}
+                                                    >
+                                                        <Button
+                                                            variant="outlined"
+                                                            color="primary"
+                                                            size="small"
+                                                            sx={{ ml: 1 }}
+                                                        >
+                                                            Re-authorize
+                                                        </Button>
+                                                    </PlaidLinkUpdate>
                                                     <Button
                                                         variant="outlined"
                                                         color="error"
@@ -319,6 +338,20 @@ const Accounts = () => {
                         sx={{ width: '100%' }}
                     >
                         Accounts successfully unlinked!
+                    </Alert>
+                </Snackbar>
+                <Snackbar
+                    open={reauthSuccess}
+                    autoHideDuration={6000}
+                    onClose={() => setReauthSuccess(false)}
+                    anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+                >
+                    <Alert
+                        icon={<CheckCircleIcon fontSize="inherit" />}
+                        severity="success"
+                        sx={{ width: '100%' }}
+                    >
+                        Account successfully re-authorized!
                     </Alert>
                 </Snackbar>
             </Box>

--- a/frontend/src/components/PlaidLinkUpdate.js
+++ b/frontend/src/components/PlaidLinkUpdate.js
@@ -1,0 +1,55 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { usePlaidLink } from 'react-plaid-link';
+import axios from '../utils/axiosConfig';
+import { useAuth } from '../context/AuthContext';
+
+const PlaidLinkUpdate = ({ itemId, onUpdateSuccess, onUpdateExit, children }) => {
+  const [linkToken, setLinkToken] = useState(null);
+  const [error, setError] = useState(null);
+  const { user } = useAuth();
+
+  const { open, ready } = usePlaidLink({
+    token: linkToken,
+    onSuccess: (public_token, metadata) => {
+      onUpdateSuccess(metadata);
+    },
+    onExit: (err, metadata) => {
+      if (err) {
+        setError('Plaid link failed: ' + err.display_message);
+      }
+      onUpdateExit(err, metadata);
+    },
+  });
+
+  const createLinkToken = useCallback(async () => {
+    if (!user) {
+      setError('User not authenticated');
+      return;
+    }
+    try {
+      const response = await axios.post('/plaid/create_link_token', {
+        itemId: itemId,
+        userId: user._id,
+      });
+      setLinkToken(response.data.link_token);
+    } catch (err) {
+      setError('Failed to create link token. Please try again later.');
+      console.error('Error creating link token:', err);
+    }
+  }, [itemId, user]);
+
+  useEffect(() => {
+    if (ready && linkToken) {
+      open();
+    }
+  }, [ready, linkToken, open]);
+
+  return (
+    <div onClick={createLinkToken}>
+      {children}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  );
+};
+
+export default PlaidLinkUpdate;


### PR DESCRIPTION
This commit introduces the Plaid update mode functionality, allowing users to re-authorize their linked financial accounts.

Key changes:
- Added a "Re-authorize" button to the accounts page for each linked institution.
- Created a new `PlaidLinkUpdate` component on the frontend to handle the update mode flow.
- Modified the backend `/create_link_token` endpoint to accept an `itemId` and generate a `link_token` for update mode.
- Updated the `plaidApiService` to conditionally exclude the `products` array when creating a token for update mode, as per Plaid's documentation.
- Added a `getItem` method to the `plaidDbService` to retrieve item details by ID.