### PR TITLE
feat: Add optional merchant fields to transaction and mapping models

### DIFF
--- a/backend/src/models/CsvMappingTemplate.js
+++ b/backend/src/models/CsvMappingTemplate.js
@@ -10,6 +10,11 @@ const csvMappingTemplateSchema = new mongoose.Schema({
         // Optional mappings
         name: { type: String }, // For secondary description/name
         category: { type: String }, // To map CSV category to our internal categories (advanced)
+        merchant_reference_number: { type: String },
+        merchant_category_description: { type: String },
+        merchant_city: { type: String },
+        merchant_state_or_province: { type: String },
+        merchant_country_code: { type: String },
     },
     dateFormat: { type: String, default: 'YYYY-MM-DD' },
     isDefault: { type: Boolean, default: false }

--- a/backend/src/models/Transaction.js
+++ b/backend/src/models/Transaction.js
@@ -9,6 +9,11 @@ const transactionSchema = new mongoose.Schema({
     date: { type: Date, required: true },
     name: { type: String, required: true },
     merchant_name: { type: String, required: true },
+    merchant_reference_number: { type: String },
+    merchant_category_description: { type: String },
+    merchant_city: { type: String },
+    merchant_state_or_province: { type: String },
+    merchant_country_code: { type: String },
     category: {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'Category',

--- a/backend/src/routes/transactions.js
+++ b/backend/src/routes/transactions.js
@@ -182,6 +182,12 @@ router.post('/upload', async (req, res) => {
             const rawMerchant = row[mapping.merchant_name];
             const rawName = mapping.name && row[mapping.name] ? row[mapping.name] : rawMerchant;
 
+            const rawMerchantRef = mapping.merchant_reference_number && row[mapping.merchant_reference_number] ? row[mapping.merchant_reference_number] : undefined;
+            const rawMerchantCategory = mapping.merchant_category_description && row[mapping.merchant_category_description] ? row[mapping.merchant_category_description] : undefined;
+            const rawMerchantCity = mapping.merchant_city && row[mapping.merchant_city] ? row[mapping.merchant_city] : undefined;
+            const rawMerchantState = mapping.merchant_state_or_province && row[mapping.merchant_state_or_province] ? row[mapping.merchant_state_or_province] : undefined;
+            const rawMerchantCountry = mapping.merchant_country_code && row[mapping.merchant_country_code] ? row[mapping.merchant_country_code] : undefined;
+
             if (!rawDate || !rawAmount || !rawMerchant) continue; // Skip invalid rows
 
             // Basic parsing (amount could be negative or have $ signs)
@@ -212,6 +218,11 @@ router.post('/upload', async (req, res) => {
                 date,
                 name: rawName,
                 merchant_name: rawMerchant,
+                merchant_reference_number: rawMerchantRef,
+                merchant_category_description: rawMerchantCategory,
+                merchant_city: rawMerchantCity,
+                merchant_state_or_province: rawMerchantState,
+                merchant_country_code: rawMerchantCountry,
                 // Optional category logic could go here
             });
             await newTx.save();

--- a/frontend/src/components/Upload/MappingTemplates.js
+++ b/frontend/src/components/Upload/MappingTemplates.js
@@ -10,7 +10,17 @@ const MappingTemplates = () => {
     const [open, setOpen] = useState(false);
     const [newTemplate, setNewTemplate] = useState({
         name: '',
-        mapping: { date: '', amount: '', merchant_name: '', name: '' }
+        mapping: {
+            date: '',
+            amount: '',
+            merchant_name: '',
+            name: '',
+            merchant_reference_number: '',
+            merchant_category_description: '',
+            merchant_city: '',
+            merchant_state_or_province: '',
+            merchant_country_code: ''
+        }
     });
 
     useEffect(() => {
@@ -30,7 +40,20 @@ const MappingTemplates = () => {
         try {
             await axios.post('/transactions/templates', newTemplate, { withCredentials: true });
             setOpen(false);
-            setNewTemplate({ name: '', mapping: { date: '', amount: '', merchant_name: '', name: '' } });
+            setNewTemplate({
+                name: '',
+                mapping: {
+                    date: '',
+                    amount: '',
+                    merchant_name: '',
+                    name: '',
+                    merchant_reference_number: '',
+                    merchant_category_description: '',
+                    merchant_city: '',
+                    merchant_state_or_province: '',
+                    merchant_country_code: ''
+                }
+            });
             fetchTemplates();
         } catch (error) {
             console.error("Error saving template", error);
@@ -102,6 +125,26 @@ const MappingTemplates = () => {
                      <TextField
                         margin="dense" label="Secondary Description CSV Header (Optional)" fullWidth
                         value={newTemplate.mapping.name} onChange={(e) => setNewTemplate({ ...newTemplate, mapping: { ...newTemplate.mapping, name: e.target.value } })}
+                    />
+                    <TextField
+                        margin="dense" label="Merchant Reference Number CSV Header (Optional)" fullWidth
+                        value={newTemplate.mapping.merchant_reference_number} onChange={(e) => setNewTemplate({ ...newTemplate, mapping: { ...newTemplate.mapping, merchant_reference_number: e.target.value } })}
+                    />
+                    <TextField
+                        margin="dense" label="Merchant Category Description CSV Header (Optional)" fullWidth
+                        value={newTemplate.mapping.merchant_category_description} onChange={(e) => setNewTemplate({ ...newTemplate, mapping: { ...newTemplate.mapping, merchant_category_description: e.target.value } })}
+                    />
+                    <TextField
+                        margin="dense" label="Merchant City CSV Header (Optional)" fullWidth
+                        value={newTemplate.mapping.merchant_city} onChange={(e) => setNewTemplate({ ...newTemplate, mapping: { ...newTemplate.mapping, merchant_city: e.target.value } })}
+                    />
+                    <TextField
+                        margin="dense" label="Merchant State/Province CSV Header (Optional)" fullWidth
+                        value={newTemplate.mapping.merchant_state_or_province} onChange={(e) => setNewTemplate({ ...newTemplate, mapping: { ...newTemplate.mapping, merchant_state_or_province: e.target.value } })}
+                    />
+                    <TextField
+                        margin="dense" label="Merchant Country Code CSV Header (Optional)" fullWidth
+                        value={newTemplate.mapping.merchant_country_code} onChange={(e) => setNewTemplate({ ...newTemplate, mapping: { ...newTemplate.mapping, merchant_country_code: e.target.value } })}
                     />
                 </DialogContent>
                 <DialogActions>


### PR DESCRIPTION
Added new optional fields for merchant details directly to the `Transaction` schema and `CsvMappingTemplate` schema mappings:
- merchant_reference_number
- merchant_category_description
- merchant_city
- merchant_state_or_province
- merchant_country_code

Updated the backend CSV upload route to correctly map, extract, and save these new fields when creating new transactions.

Updated the frontend MappingTemplates component to expose TextFields for these new mapping properties.