### PR TITLE
feat: Add dual-column support for CSV mapping templates

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -562,6 +562,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.1"
       },

--- a/backend/src/models/CsvMappingTemplate.js
+++ b/backend/src/models/CsvMappingTemplate.js
@@ -5,9 +5,11 @@ const csvMappingTemplateSchema = new mongoose.Schema({
     name: { type: String, required: true },
     mapping: {
         date: { type: String, required: true },
-        amount: { type: String, required: true },
+        amount: { type: String }, // Optional if amount_in/amount_out are used
         merchant_name: { type: String, required: true },
         // Optional mappings
+        amount_in: { type: String }, // For Funds In column
+        amount_out: { type: String }, // For Funds Out column
         name: { type: String }, // For secondary description/name
         category: { type: String }, // To map CSV category to our internal categories (advanced)
         merchant_reference_number: { type: String },

--- a/backend/src/routes/transactions.js
+++ b/backend/src/routes/transactions.js
@@ -178,7 +178,9 @@ router.post('/upload', async (req, res) => {
         for (const row of transactions) {
             // Apply mapping
             const rawDate = row[mapping.date];
-            const rawAmount = row[mapping.amount];
+            const rawAmount = mapping.amount ? row[mapping.amount] : undefined;
+            const rawAmountIn = mapping.amount_in ? row[mapping.amount_in] : undefined;
+            const rawAmountOut = mapping.amount_out ? row[mapping.amount_out] : undefined;
             const rawMerchant = row[mapping.merchant_name];
             const rawName = mapping.name && row[mapping.name] ? row[mapping.name] : rawMerchant;
 
@@ -188,17 +190,35 @@ router.post('/upload', async (req, res) => {
             const rawMerchantState = mapping.merchant_state_or_province && row[mapping.merchant_state_or_province] ? row[mapping.merchant_state_or_province] : undefined;
             const rawMerchantCountry = mapping.merchant_country_code && row[mapping.merchant_country_code] ? row[mapping.merchant_country_code] : undefined;
 
-            if (!rawDate || !rawAmount || !rawMerchant) continue; // Skip invalid rows
+            if (!rawDate || !rawMerchant) continue; // Skip invalid rows
+            if (!rawAmount && !rawAmountIn && !rawAmountOut) continue; // Must have some amount mapping
 
-            // Basic parsing (amount could be negative or have $ signs)
-            let amountStr = String(rawAmount).replace(/[^\d.-]/g, '');
-            let amount = parseFloat(amountStr);
-            if (isNaN(amount)) continue;
+            let amount;
 
-            // Plaid convention: positive amount is an expense, negative is income/refund
-            // For standard bank CSVs, withdrawals/expenses are often negative. We need to invert it for our DB if so.
-            // Let's assume standard logic: if it's negative in CSV, it's an expense (positive in our DB).
-            amount = -amount;
+            if (rawAmountIn || rawAmountOut) {
+                // Dual column logic
+                let amountIn = rawAmountIn ? parseFloat(String(rawAmountIn).replace(/[^\d.-]/g, '')) : NaN;
+                let amountOut = rawAmountOut ? parseFloat(String(rawAmountOut).replace(/[^\d.-]/g, '')) : NaN;
+
+                // If both are present, we subtract in from out to get net expense.
+                // Usually they are mutually exclusive.
+                if (isNaN(amountIn)) amountIn = 0;
+                if (isNaN(amountOut)) amountOut = 0;
+
+                if (amountIn === 0 && amountOut === 0) continue;
+
+                // Plaid Convention: positive is expense (out), negative is income (in).
+                amount = amountOut - amountIn;
+            } else {
+                // Single column logic
+                let amountStr = String(rawAmount).replace(/[^\d.-]/g, '');
+                amount = parseFloat(amountStr);
+                if (isNaN(amount)) continue;
+
+                // Plaid convention: positive amount is an expense, negative is income/refund
+                // For standard bank CSVs, withdrawals/expenses are often negative. We need to invert it for our DB if so.
+                amount = -amount;
+            }
 
             const date = new Date(rawDate);
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6532,6 +6532,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.1"
       },

--- a/frontend/src/components/Upload/MappingTemplates.js
+++ b/frontend/src/components/Upload/MappingTemplates.js
@@ -13,6 +13,8 @@ const MappingTemplates = () => {
         mapping: {
             date: '',
             amount: '',
+            amount_in: '',
+            amount_out: '',
             merchant_name: '',
             name: '',
             merchant_reference_number: '',
@@ -45,6 +47,8 @@ const MappingTemplates = () => {
                 mapping: {
                     date: '',
                     amount: '',
+                    amount_in: '',
+                    amount_out: '',
                     merchant_name: '',
                     name: '',
                     merchant_reference_number: '',
@@ -81,6 +85,7 @@ const MappingTemplates = () => {
                             <TableCell>Template Name</TableCell>
                             <TableCell>Date Column</TableCell>
                             <TableCell>Amount Column</TableCell>
+                            <TableCell>Amount In/Out</TableCell>
                             <TableCell>Merchant Column</TableCell>
                             <TableCell>Actions</TableCell>
                         </TableRow>
@@ -91,6 +96,11 @@ const MappingTemplates = () => {
                                 <TableCell>{template.name}</TableCell>
                                 <TableCell>{template.mapping.date}</TableCell>
                                 <TableCell>{template.mapping.amount}</TableCell>
+                                <TableCell>
+                                    {template.mapping.amount_in || template.mapping.amount_out
+                                        ? `In: ${template.mapping.amount_in || '-'}, Out: ${template.mapping.amount_out || '-'}`
+                                        : '-'}
+                                </TableCell>
                                 <TableCell>{template.mapping.merchant_name}</TableCell>
                                 <TableCell>
                                     <IconButton onClick={() => handleDelete(template._id)} color="error">
@@ -115,8 +125,16 @@ const MappingTemplates = () => {
                         value={newTemplate.mapping.date} onChange={(e) => setNewTemplate({ ...newTemplate, mapping: { ...newTemplate.mapping, date: e.target.value } })}
                     />
                     <TextField
-                        margin="dense" label="Amount CSV Header" fullWidth
+                        margin="dense" label="Amount CSV Header (Optional if using In/Out)" fullWidth
                         value={newTemplate.mapping.amount} onChange={(e) => setNewTemplate({ ...newTemplate, mapping: { ...newTemplate.mapping, amount: e.target.value } })}
+                    />
+                    <TextField
+                        margin="dense" label="Funds In CSV Header (Optional)" fullWidth
+                        value={newTemplate.mapping.amount_in || ''} onChange={(e) => setNewTemplate({ ...newTemplate, mapping: { ...newTemplate.mapping, amount_in: e.target.value } })}
+                    />
+                    <TextField
+                        margin="dense" label="Funds Out CSV Header (Optional)" fullWidth
+                        value={newTemplate.mapping.amount_out || ''} onChange={(e) => setNewTemplate({ ...newTemplate, mapping: { ...newTemplate.mapping, amount_out: e.target.value } })}
                     />
                     <TextField
                         margin="dense" label="Merchant CSV Header" fullWidth


### PR DESCRIPTION
- Updated `CsvMappingTemplate` schema to include optional `amount_in` and `amount_out` fields.
- Updated `/upload` route to calculate `amount` based on Plaid's polarity rules when dual columns are provided.
- Added UI inputs for "Funds In" and "Funds Out" to the frontend mapping template creation form.